### PR TITLE
Features/signup

### DIFF
--- a/lib/features/login/ui/login_screen.dart
+++ b/lib/features/login/ui/login_screen.dart
@@ -7,7 +7,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import '../../../core/helpers/spacing.dart';
-import '../data/models/login_request_body.dart';
 import '../logic/cubit/login_cubit.dart';
 import 'widgets/email_and_password.dart';
 import 'widgets/login_bloc_listener.dart';

--- a/lib/features/signup/ui/signup_screen.dart
+++ b/lib/features/signup/ui/signup_screen.dart
@@ -18,40 +18,41 @@ class SignupScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.symmetric(horizontal: 30.w, vertical: 30.h),
-          child: SingleChildScrollView(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('Create Account', style: TextStyles.font24BlueBold),
-                verticalSpace(8),
-                Text(
-                  'Sign up now and start exploring all that our app has to offer. We\'re excited to welcome you to our community!',
-                  style: TextStyles.font14GreyRegular,
-                ),
-                verticalSpace(36),
-                Column(
-                  children: [
-                    const SignupForm(),
-                    verticalSpace(40),
-                    AppTextButton(
-                      buttonText: "Create Account",
-                      textStyle: TextStyles.font16WhiteSemiBold,
-                      onPressed: () {
-                        validateThenDoSignup(context);
-                      },
-                    ),
-                    verticalSpace(16),
-                    const TermsAndConditionsText(),
-                    verticalSpace(30),
-                    const AlreadyHaveAccountText(),
-                    const SignupBlocListener(),
-                  ],
-                ),
-              ],
+    return SignupBlocListener(
+      child: Scaffold(
+        body: SafeArea(
+          child: Padding(
+            padding: EdgeInsets.symmetric(horizontal: 30.w, vertical: 30.h),
+            child: SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('Create Account', style: TextStyles.font24BlueBold),
+                  verticalSpace(8),
+                  Text(
+                    'Sign up now and start exploring all that our app has to offer. We\'re excited to welcome you to our community!',
+                    style: TextStyles.font14GreyRegular,
+                  ),
+                  verticalSpace(36),
+                  Column(
+                    children: [
+                      const SignupForm(),
+                      verticalSpace(40),
+                      AppTextButton(
+                        buttonText: "Create Account",
+                        textStyle: TextStyles.font16WhiteSemiBold,
+                        onPressed: () {
+                          validateThenDoSignup(context);
+                        },
+                      ),
+                      verticalSpace(16),
+                      const TermsAndConditionsText(),
+                      verticalSpace(30),
+                      const AlreadyHaveAccountText(),
+                    ],
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/features/signup/ui/widgets/sign_up_bloc_listener.dart
+++ b/lib/features/signup/ui/widgets/sign_up_bloc_listener.dart
@@ -9,7 +9,9 @@ import '../../logic/cubit/signup_cubit.dart';
 import '../../logic/cubit/signup_state.dart';
 
 class SignupBlocListener extends StatelessWidget {
-  const SignupBlocListener({super.key});
+  final Widget child;
+
+  const SignupBlocListener({super.key, required this.child});
 
   @override
   Widget build(BuildContext context) {
@@ -20,6 +22,7 @@ class SignupBlocListener extends StatelessWidget {
           signupLoading: () {
             showDialog(
               context: context,
+              barrierDismissible: false,
               builder: (context) => const Center(child: CircularProgressIndicator(color: ColorsManager.mainBlue)),
             );
           },
@@ -32,7 +35,7 @@ class SignupBlocListener extends StatelessWidget {
           },
         );
       },
-      child: const SizedBox.shrink(),
+      child: child,
     );
   }
 
@@ -47,11 +50,7 @@ class SignupBlocListener extends StatelessWidget {
           ),
           actions: <Widget>[
             TextButton(
-              style: TextButton.styleFrom(
-                foregroundColor: Colors.white,
-                backgroundColor: Colors.blue,
-                disabledForegroundColor: Colors.grey.withOpacity(0.38),
-              ),
+              style: TextButton.styleFrom(foregroundColor: Colors.white, backgroundColor: Colors.blue),
               onPressed: () {
                 context.pushNamed(Routes.loginScreen);
               },

--- a/lib/main_development.dart
+++ b/lib/main_development.dart
@@ -1,10 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_advanced_course/core/di/dependency_injection.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import 'core/routing/app_router.dart';
 import 'doc_app.dart';
 
-void main() {
+void main() async {
   setupGetIt();
+  await ScreenUtil.ensureScreenSize();
+
   runApp(DocApp(appRouter: AppRouter()));
 }

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_advanced_course/core/di/dependency_injection.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import 'core/routing/app_router.dart';
 import 'doc_app.dart';
 
-void main() {
+void main() async {
   setupGetIt();
+  await ScreenUtil.ensureScreenSize();
   runApp(DocApp(appRouter: AppRouter()));
 }


### PR DESCRIPTION
1 refactor(signup): Use wrapping SignupBlocListener                                                                                                                                            │
│    2                                                                                                                                                                                              │
│    3 - Refactor `SignupScreen` to be wrapped by `SignupBlocListener` for better separation of concerns and to handle UI state changes more cleanly.                                               │
│    4 - Make `SignupBlocListener` a reusable widget that accepts a child.                                                                                                                          │
│    5 - Prevent accidental dismissal of the loading indicator during signup by setting `barrierDismissible` to `false`.                                                                            │
│    6 - Ensure `ScreenUtil` is initialized before the app runs in both development and production entry points. 